### PR TITLE
Calendar widget: Add customizable fields for Calendar widget

### DIFF
--- a/components/widgets/Calendar/DaysOfMonth.tsx
+++ b/components/widgets/Calendar/DaysOfMonth.tsx
@@ -4,14 +4,25 @@ import { DayOfMonthType } from './types';
 type DaysOfMonthProps = {
   daysOfMonth: DayOfMonthType[];
   enableLunarCalendar?: boolean;
+  accentColor: string;
+  textColor: string;
 };
 
 export default function DaysOfMonth({
   daysOfMonth,
   enableLunarCalendar,
+  accentColor,
+  textColor,
 }: DaysOfMonthProps) {
   return (
-    <div className="mt-2 grid grid-cols-7 gap-1 gap-y-2">
+    <div
+      className="mt-2 grid grid-cols-7 gap-1 gap-y-2"
+      style={{
+        ['--text' as any]: textColor,
+        ['--accent' as any]: accentColor,
+        color: textColor,
+      }}
+    >
       {daysOfMonth.map((day, index) =>
         // prettier-ignore
         <div
@@ -19,12 +30,15 @@ export default function DaysOfMonth({
           className={cn(
             'relative rounded-md border-2 border-dashed border-transparent py-5',
             {
-              'bg-[#f64338] text-white': day?.isCurrentDay,
-              'text-[#949494] dark:text-[#a8a8a8]': !day?.isCurrentDay && day?.isWeekendDay,
-              'text-[#dbdbdb] dark:text-[#5d5d5d]': day?.isNotCurrentMonthDay,
-              '!border-[#f64338]': day?.isSelectedDay,
+              'text-white': day?.isCurrentDay,
+              'text-[var(--text)]/50 dark:text-[#a8a8a8]': !day?.isCurrentDay && day?.isWeekendDay,
+              'text-[var(--text)]/20 dark:text-[#5d5d5d]': day?.isNotCurrentMonthDay,
             },
           )}
+          style={{
+            backgroundColor: day?.isCurrentDay ? accentColor : '',
+            borderColor: day?.isSelectedDay ? accentColor : '',
+          }}
         >
           <div
             className={`absolute ${enableLunarCalendar ? 'top-[60%]' : 'top-1/2'} left-1/2 flex -translate-x-1/2 -translate-y-1/2 flex-col items-center`}
@@ -36,8 +50,7 @@ export default function DaysOfMonth({
             {enableLunarCalendar && day.value && (
               <span
                 className={cn(`-mt-0.5 ml-4 text-[0.65rem]`, {
-                  'text-[#9b9b9b]': !day?.isCurrentDay && day?.isWeekendDay,
-                  'text-red-500': day.lunarValue?.get().day == 1 && !day?.isCurrentDay,
+                  'text-[var(--accent)]': day.lunarValue?.get().day == 1 && !day?.isCurrentDay,
                 })}
               >
                 {day.lunarValue?.get().day === 1

--- a/components/widgets/Calendar/DaysOfWeek.tsx
+++ b/components/widgets/Calendar/DaysOfWeek.tsx
@@ -1,13 +1,19 @@
 'use client';
 
 import { useEffect, useState } from 'react';
-import { FirstDayOfWeekType } from './types';
+import { FirstDayOfWeekType, WeekdayFormatType } from './types';
 
 type DaysOfWeekProps = {
   firstDayOfWeek: FirstDayOfWeekType;
+  weekdayFormat: WeekdayFormatType;
+  textColor: string;
 };
 
-export default function DaysOfWeek({ firstDayOfWeek }: DaysOfWeekProps) {
+export default function DaysOfWeek({
+  firstDayOfWeek,
+  weekdayFormat,
+  textColor,
+}: DaysOfWeekProps) {
   const [daysOfWeek, setDaysOfWeek] = useState([
     { value: 'Mon', isWeekend: false },
     { value: 'Tue', isWeekend: false },
@@ -35,13 +41,14 @@ export default function DaysOfWeek({ firstDayOfWeek }: DaysOfWeekProps) {
   }, [firstDayOfWeek, daysOfWeek]);
 
   return (
-    <div className="mt-2 grid grid-cols-7 gap-1 font-semibold">
+    <div className="mt-2 grid grid-cols-7 gap-1 text-base font-semibold">
       {daysOfWeek.map((day, index) => (
         <div
           key={index}
           className={`text-center ${day.isWeekend ? 'text-[#9b9b9b]' : ''}`}
+          style={{ color: textColor, opacity: day.isWeekend ? '50%' : undefined }}
         >
-          {day.value.slice(0, 1)}
+          {day.value.slice(0, weekdayFormat === '2-char' ? 2 : 1)}
         </div>
       ))}
     </div>

--- a/components/widgets/Calendar/MonthNavigator.tsx
+++ b/components/widgets/Calendar/MonthNavigator.tsx
@@ -4,18 +4,24 @@ import { ChevronLeft, ChevronRight } from 'lucide-react';
 
 type MonthNavigatorProps = {
   selectedTime: { month: number; year: number };
+  accentColor: string;
   onMonthChange: (newTime: { month: number; year: number }) => void;
 };
 
 export default function MonthNavigator({
+  accentColor,
   selectedTime,
   onMonthChange,
 }: MonthNavigatorProps) {
   const date = new Date(selectedTime.year, selectedTime.month);
+  // #f64338
 
   return (
     <div className="group flex items-center justify-between">
-      <div className="col-span-4 ml-3 flex items-center font-semibold text-[#f64338] uppercase">
+      <div
+        className="col-span-4 ml-3 flex items-center font-semibold uppercase"
+        style={{ color: accentColor }}
+      >
         {format(date, 'MMMM yyyy')}
       </div>
 

--- a/components/widgets/Calendar/index.tsx
+++ b/components/widgets/Calendar/index.tsx
@@ -5,13 +5,17 @@ import DaysOfMonth from './DaysOfMonth';
 import MonthNavigator from './MonthNavigator';
 import { createContext, useMemo, useState } from 'react';
 import { generateDaysOfMonth } from './services';
-import { FirstDayOfWeekType, MonthRange, SelectedTime } from './types';
+import { FirstDayOfWeekType, MonthRange, SelectedTime, WeekdayFormatType } from './types';
 import { getWidgetSize } from '@/configs/widgetSizes';
 import { WidgetType } from '@/types/widget';
 
 type CalendarProps = {
   enableLunarCalendar?: boolean;
   firstDayOfWeek?: FirstDayOfWeekType;
+  weekdayFormat?: WeekdayFormatType;
+  accentColor?: string;
+  textColor?: string;
+  bgColor?: string;
 };
 
 export const CalendarContext = createContext({
@@ -22,6 +26,10 @@ export const CalendarContext = createContext({
 export default function Calendar({
   enableLunarCalendar = true,
   firstDayOfWeek = 'Sunday',
+  weekdayFormat = '1-char',
+  accentColor = 'green',
+  textColor = 'black',
+  bgColor = 'white',
 }: CalendarProps) {
   const size = getWidgetSize(WidgetType.CALENDAR);
 
@@ -49,18 +57,28 @@ export default function Calendar({
   return (
     <CalendarContext.Provider value={{ selectedTime, changeTime: onMonthChange }}>
       <div
-        className="rounded-3xl bg-white px-4 py-5 shadow-[0_4px_12px_0_rgba(0,0,0,0.1)] select-none dark:bg-[#2e2e2e]"
-        style={{ width: size.width, height: size.height }}
+        className="rounded-3xl px-4 py-5 shadow-[0_4px_12px_0_rgba(0,0,0,0.1)] select-none dark:bg-[#2e2e2e]"
+        style={{ width: size.width, height: size.height, backgroundColor: bgColor }}
       >
-        <MonthNavigator selectedTime={selectedTime} onMonthChange={onMonthChange} />
+        <MonthNavigator
+          selectedTime={selectedTime}
+          onMonthChange={onMonthChange}
+          accentColor={accentColor}
+        />
 
         <div
           className={`${enableLunarCalendar ? 'text-base' : 'text-sm'} mt-5 font-semibold dark:text-white`}
         >
-          <DaysOfWeek firstDayOfWeek={firstDayOfWeek} />
+          <DaysOfWeek
+            firstDayOfWeek={firstDayOfWeek}
+            weekdayFormat={weekdayFormat}
+            textColor={textColor}
+          />
           <DaysOfMonth
             daysOfMonth={daysOfMonth}
             enableLunarCalendar={enableLunarCalendar}
+            accentColor={accentColor}
+            textColor={textColor}
           />
         </div>
       </div>

--- a/components/widgets/Calendar/types.ts
+++ b/components/widgets/Calendar/types.ts
@@ -10,5 +10,6 @@ export type DayOfMonthType = {
 };
 
 export type FirstDayOfWeekType = 'Sunday' | 'Monday';
+export type WeekdayFormatType = '1-char' | '2-char';
 export type MonthRange = 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11;
 export type SelectedTime = { day?: number; month: number; year: number };

--- a/configs/widgetConfigs.ts
+++ b/configs/widgetConfigs.ts
@@ -106,10 +106,52 @@ export const WIDGET_CONFIGS: Record<WidgetType, WidgetConfig> = {
     type: WidgetType.CALENDAR,
     customizeFields: [
       {
+        prop: 'accentColor',
+        type: 'COLOR',
+        label: 'Accent Color',
+        defaultValue: '#000',
+      },
+      {
         prop: 'textColor',
         type: 'COLOR',
         label: 'Text Color',
         defaultValue: '#000',
+      },
+      {
+        prop: 'bgColor',
+        type: 'COLOR',
+        label: 'Background Color',
+        defaultValue: '#fff',
+      },
+      {
+        prop: 'enableLunarCalendar',
+        type: 'SWITCHER',
+        label: 'Lunar Calendar',
+        options: [
+          { label: 'On', value: true },
+          { label: 'Off', value: false },
+        ],
+        defaultValue: true,
+      },
+      {
+        prop: 'firstDayOfWeek',
+        type: 'SWITCHER',
+        label: 'First Day of Week',
+        options: [
+          { label: 'Sunday', value: 'Sunday' },
+          { label: 'Monday', value: 'Monday' },
+        ],
+        defaultValue: 'Sunday',
+      },
+      {
+        prop: 'weekdayFormat',
+        type: 'SWITCHER',
+        label: 'Weekday Format',
+        options: [
+          { label: '1 char', value: '1-char' },
+          { label: '2 char', value: '2-char' },
+        ],
+        defaultValue: '1-char',
       },
     ],
   },


### PR DESCRIPTION
## What is purpose of this PR?

- Add customizable colors and weekday format for DaysOfMonth and DaysOfWeek components
- Add customizable fields for Calendar widget

### Evidence (Screenshots, Recordings)
*Use screenshots/recording videos to demonstrate what has changed (Before and After).*
Before | After
:--: | :--:
<img width="404" height="492" alt="image" src="https://github.com/user-attachments/assets/c0e227ec-4684-4da5-8d75-086ba230d33b" /> | <img width="413" height="489" alt="image" src="https://github.com/user-attachments/assets/eb156737-e1b9-43b4-aa88-b8cb4fe463d0" />
