### PR TITLE
feat/world-clock: update default timezone from 'UTC' to 'Asia/Bangkok'

### DIFF
--- a/components/base/TimezoneCombobox.tsx
+++ b/components/base/TimezoneCombobox.tsx
@@ -65,7 +65,7 @@ export const TimezoneCombobox = ({
     if (!searchQuery) {
       // Show only popular timezones initially
       const popularTimezones = [
-        'UTC',
+        'Asia/Bangkok',
         'America/New_York',
         'America/Los_Angeles',
         'America/Chicago',


### PR DESCRIPTION
## What is purpose of this PR?

- Update default popular timezone from 'UTC' to 'Asia/Bangkok'

### Evidence (Screenshots, Recordings)
*Use screenshots/recording videos to demonstrate what has changed (Before and After).*

<img width="335" height="533" alt="image" src="https://github.com/user-attachments/assets/100812cb-2646-4f89-8d34-7b6dd4a85812" />

